### PR TITLE
fixed the ordering of ArithExpr

### DIFF
--- a/src/main/lift/arithmetic/ArithExpr.scala
+++ b/src/main/lift/arithmetic/ArithExpr.scala
@@ -397,7 +397,7 @@ object ArithExpr {
     case (Cst(a), Cst(b)) => a < b
     case (_: Cst, _) => true // constants first
     case (_, _: Cst) => false
-    case (x:NamedVar, y:NamedVar) => x.name.compareTo(y.name) <= 0
+    case (x:NamedVar, y:NamedVar) => x.name.compareTo(y.name) < 0
     case (x: Var, y: Var) => x.id < y.id // order variables based on id
     case (_: Var, _) => true // variables always after constants second
     case (_, _: Var) => false

--- a/src/main/lift/arithmetic/ArithExpr.scala
+++ b/src/main/lift/arithmetic/ArithExpr.scala
@@ -401,7 +401,11 @@ object ArithExpr {
     case (x: Var, y: Var) => x.id < y.id // order variables based on id
     case (_: Var, _) => true // variables always after constants second
     case (_, _: Var) => false
-    case (Prod(factors1), Prod(factors2)) => factors1.zip(factors2).map(x => isCanonicallySorted(x._1, x._2)).foldLeft(false)(_ || _)
+    case (Prod(factors1), Prod(factors2)) =>
+      factors1.zip(factors2).dropWhile(x => x._1 == x._2).headOption match {
+        case None => false
+        case Some(x) => isCanonicallySorted(x._1, x._2)
+      }
     case _ => x.HashSeed() < y.HashSeed() || (x.HashSeed() == y.HashSeed() && x.digest() < y.digest())
   }
 

--- a/src/test/lift/testing/TestExpr.scala
+++ b/src/test/lift/testing/TestExpr.scala
@@ -1102,6 +1102,15 @@ class TestExpr {
     assertEquals(Cst(1), Cst(1) /^ Cst(1))
   }
 
+  @Test def orderOfArithExpr(): Unit = {
+    val x = NamedVar("x")
+    val a = NamedVar("a")
+    val b = NamedVar("b")
+    val l1 = List(x * a, x * b).sortWith(ArithExpr.isCanonicallySorted)
+    val l2 = l1.sortWith(ArithExpr.isCanonicallySorted)
+    assertEquals(l1, l2)
+  }
+
   @Test def NByN(): Unit = {
     val N = SizeVar("N")
     assertEquals(Cst(1), N /^ N)

--- a/src/test/lift/testing/TestExpr.scala
+++ b/src/test/lift/testing/TestExpr.scala
@@ -1109,6 +1109,14 @@ class TestExpr {
     val l1 = List(x * a, x * b).sortWith(ArithExpr.isCanonicallySorted)
     val l2 = l1.sortWith(ArithExpr.isCanonicallySorted)
     assertEquals(l1, l2)
+
+    val n1 = NamedVar("n1")
+    val n2 = NamedVar("n2")
+    val n3 = NamedVar("n3")
+    val n4 = NamedVar("n4")
+    val l3 = List(n1 * n4, n2 * n3).sortWith(ArithExpr.isCanonicallySorted)
+    val l4 = l3.sortWith(ArithExpr.isCanonicallySorted)
+    assertEquals(l3, l4)
   }
 
   @Test def NByN(): Unit = {


### PR DESCRIPTION
This should fix the issue that some `ArithExpr`s are always swapped during sorting.
* use `<` instead of `<=` while comparing `NamedVar`s.
* use dictionary order while comparing `Prod`s.