### PR TITLE
Faster substitution implementation than with visitAndRebuild

### DIFF
--- a/src/main/scala/arithexpr/arithmetic/BoolExpr.scala
+++ b/src/main/scala/arithexpr/arithmetic/BoolExpr.scala
@@ -14,6 +14,8 @@ sealed trait BoolExpr {
 
   def visitAndRebuild(f:ArithExpr => ArithExpr):BoolExpr
 
+  def substitute(subs: collection.Map[ArithExpr, ArithExpr]): Option[BoolExpr]
+
   def simplifyInnerArithExpr:BoolExpr
 
   def freeVariables():Set[Var]
@@ -32,6 +34,8 @@ object BoolExpr {
 
     override def visitAndRebuild(f: ArithExpr => ArithExpr) = this
 
+    override def substitute(subs: collection.Map[ArithExpr, ArithExpr]): Option[BoolExpr] = None
+
     override def freeVariables() = Set()
   }
   case object False extends BoolExpr {
@@ -42,6 +46,8 @@ object BoolExpr {
     override def visit(f: ArithExpr => Unit) = ()
 
     override def visitAndRebuild(f: ArithExpr => ArithExpr) = this
+
+    override def substitute(subs: collection.Map[ArithExpr, ArithExpr]): Option[BoolExpr] = None
 
     override def freeVariables() = Set()
 
@@ -57,6 +63,16 @@ object BoolExpr {
     }
 
     override def visitAndRebuild(f: ArithExpr => ArithExpr) = arithPredicate(lhs.visitAndRebuild(f), rhs.visitAndRebuild(f), op)
+
+    override def substitute(subs: collection.Map[ArithExpr, ArithExpr]): Option[BoolExpr] = {
+      val ls = lhs.substitute(subs)
+      val rs = rhs.substitute(subs)
+      if (ls.isEmpty && rs.isEmpty) {
+        None
+      } else {
+        Some(arithPredicate(ls.getOrElse(lhs), rs.getOrElse(rhs), op))
+      }
+    }
 
     override def freeVariables() = ArithExpr.freeVariables(lhs).union(ArithExpr.freeVariables(rhs))
 

--- a/src/test/scala/arithexpr/testing/Regressions.scala
+++ b/src/test/scala/arithexpr/testing/Regressions.scala
@@ -81,6 +81,9 @@ class Regressions {
     override def visitAndRebuild(f: (ArithExpr) => ArithExpr): ArithExpr =
       f(this)
 
+    override def substitute(subs: collection.Map[ArithExpr, ArithExpr]): Option[ArithExpr] =
+      None
+
     override def exposedArgs: Seq[ArithExpr] = ???
 
     override def substituteExposedArgs(subMap: Map[ArithExpr, SimplifiedExpr]): ArithExprFunctionCall = ???
@@ -96,6 +99,9 @@ class Regressions {
     override lazy val (min : ArithExpr, max: ArithExpr) = (Cst(0),PosInf)
 
     override def visitAndRebuild(f: (ArithExpr) => ArithExpr): ArithExpr = ???
+
+    override def substitute(subs: collection.Map[ArithExpr, ArithExpr]): Option[ArithExpr] =
+      None
 
     override def exposedArgs: Seq[ArithExpr] = ???
 
@@ -149,6 +155,9 @@ class Regressions {
 
       override def visitAndRebuild(f: (ArithExpr) => ArithExpr): ArithExpr =
         f(this)
+
+      override def substitute(subs: collection.Map[ArithExpr, ArithExpr]): Option[ArithExpr] =
+        subs.get(this)
 
       override def exposedArgs: Seq[ArithExpr] = ???
 

--- a/src/test/scala/arithexpr/testing/TestExpr.scala
+++ b/src/test/scala/arithexpr/testing/TestExpr.scala
@@ -23,6 +23,9 @@ class OclTestFunction private(name: String, range: Range)
   override def visitAndRebuild(f: (ArithExpr) => ArithExpr): ArithExpr =
     f(new OclTestFunction(name, range.visitAndRebuild(f)))
 
+  override def substitute(subs: collection.Map[ArithExpr, ArithExpr]): Option[ArithExpr] =
+    subs.get(this).orElse(range.substitute(subs).map(new OclTestFunction(name, _)))
+
   override def exposedArgs: Seq[ArithExpr] = ???
 
   override def substituteExposedArgs(subMap: Map[ArithExpr, SimplifiedExpr]): ArithExprFunctionCall = ???


### PR DESCRIPTION
The idea is to avoid triggering arithexpr simplification when no substitutions are made in an expression.
This should make type inference and codegen faster in shine.

On the demosaic image processing expression, type inference + codegen time goes from 1mn+ to 30s.

Opinions? @rise-lang/core 
I also thought about potentially avoiding visiting some sub-trees entirely by keeping track of the set of variables in the sub-tree. If there are no variables in the substitution map we could completly skip visiting the sub-tree. Although this seems like more work for a more unclear trade-off.