### PR TITLE
RangeAdd.max bugfix

### DIFF
--- a/src/main/scala/arithexpr/arithmetic/Range.scala
+++ b/src/main/scala/arithexpr/arithmetic/Range.scala
@@ -117,7 +117,7 @@ case class RangeAdd(start: ArithExpr with SimplifiedExpr,
       case NotEvaluableException() => result
     }
   }
-  
+
   override val min: ArithExpr with SimplifiedExpr = {
     if (step.sign == Sign.Negative)
       checkBound(up=false, stop + 1)
@@ -128,8 +128,10 @@ case class RangeAdd(start: ArithExpr with SimplifiedExpr,
     if (step.sign == Sign.Positive)
       // TODO: this maximum is too high! consider the following range: RangeAdd(0,10,5) in which case the max is 5, not 9
       checkBound(up=true, stop - 1)
-    else
+    else if (step.sign == Sign.Negative)
       start
+    else
+      stop
   }
 
   override def equals(that: Any): Boolean = that match {

--- a/src/main/scala/arithexpr/arithmetic/simplifier/SimplifyProd.scala
+++ b/src/main/scala/arithexpr/arithmetic/simplifier/SimplifyProd.scala
@@ -37,16 +37,16 @@ object SimplifyProd {
                 factorsComeFromProd: Boolean = false,
                 someFactorsComeFromSum: Boolean = true,
                 someFactorsComeFromPow: Boolean = true): ArithExpr with SimplifiedExpr = {
+    var i = 0
+    factors.foreach { x =>
+      val newfac = combineFactors(factor, x,
+        distributionAllowed = !someFactorsComeFromSum,
+        powerMergeAllowed = !someFactorsComeFromPow)
 
-    factors.zipWithIndex.foreach{
-      case (x, i) => {
-        val newfac = combineFactors(factor, x,
-          distributionAllowed = !someFactorsComeFromSum,
-          powerMergeAllowed = !someFactorsComeFromPow)
+      if (newfac.isDefined)
+        return replaceAt(i, newfac.get, factors).reduce(_ * _)
 
-        if (newfac.isDefined)
-          return replaceAt(i, newfac.get, factors).reduce(_ * _)
-      }
+      i += 1
     }
 
     // We didn't manage to combine the new factor with any of the old factors.

--- a/src/main/scala/arithexpr/arithmetic/simplifier/SimplifyProd.scala
+++ b/src/main/scala/arithexpr/arithmetic/simplifier/SimplifyProd.scala
@@ -37,6 +37,7 @@ object SimplifyProd {
                 factorsComeFromProd: Boolean = false,
                 someFactorsComeFromSum: Boolean = true,
                 someFactorsComeFromPow: Boolean = true): ArithExpr with SimplifiedExpr = {
+    // Avoids using `zipWithIndex` with creates boxed integers, hurting performance
     var i = 0
     factors.foreach { x =>
       val newfac = combineFactors(factor, x,

--- a/src/main/scala/arithexpr/arithmetic/simplifier/SimplifySum.scala
+++ b/src/main/scala/arithexpr/arithmetic/simplifier/SimplifySum.scala
@@ -25,11 +25,12 @@ object SimplifySum {
   def addTerm(terms: List[ArithExpr with SimplifiedExpr], term: ArithExpr with SimplifiedExpr,
               termsComeFromSum: Boolean = false):
   Either[ArithExpr with SimplifiedExpr, ArithExpr with SimplifiedExpr] = {
-    terms.zipWithIndex.foreach {
-      case (x, i) =>
-        val newterm = combineTerms(term, x)
-        if (newterm.isDefined) return Right(replaceAt(i, newterm.get, terms).reduce(_ + _))
-      }
+    var i = 0
+    terms.foreach { x =>
+      val newterm = combineTerms(term, x)
+      if (newterm.isDefined) return Right(replaceAt(i, newterm.get, terms).reduce(_ + _))
+      i += 1
+    }
 
     // We didn't manage to combine the new term with any of the old terms.
     val simplifiedOriginalSum: ArithExpr with SimplifiedExpr =

--- a/src/main/scala/arithexpr/arithmetic/simplifier/SimplifySum.scala
+++ b/src/main/scala/arithexpr/arithmetic/simplifier/SimplifySum.scala
@@ -25,6 +25,7 @@ object SimplifySum {
   def addTerm(terms: List[ArithExpr with SimplifiedExpr], term: ArithExpr with SimplifiedExpr,
               termsComeFromSum: Boolean = false):
   Either[ArithExpr with SimplifiedExpr, ArithExpr with SimplifiedExpr] = {
+    // Avoids using `zipWithIndex` with creates boxed integers, hurting performance
     var i = 0
     terms.foreach { x =>
       val newterm = combineTerms(term, x)


### PR DESCRIPTION
Also avoids using `zipWithIndex` which creates boxed `Integer`s instead of native `Int`s and has a performance cost.